### PR TITLE
Adding Cors Settings on Setup.cs

### DIFF
--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -35,6 +35,11 @@ namespace API
                     f.DisableDataAnnotationsValidation = true;
                 });
             services.AddControllers();
+            services.AddCors(options => {
+                options.AddPolicy("CorsPolicy", policy => {
+                    policy.AllowAnyHeader().AllowMethods().WithOrigin("https://localhost:4200"); // You have to indicate the Client Allowed URL 
+                });
+            });
             services.AddMemoryCache();
             services.AddApplicationServices();
             services.AddIdentityCore<AppUser>().AddRoles<IdentityRole>().AddEntityFrameworkStores<DataContext>();


### PR DESCRIPTION
It was missing Cors Settings, that's why while you try to connect the API with Client, it gives this kind of error: "Access to XMLHttpRequest at 'https://localhost:5001/api/auth' from origin 'https://localhost:4200' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource."